### PR TITLE
Create manifests for scenarios 1 & 2

### DIFF
--- a/pyramidcorp/manifests/1_default.yaml
+++ b/pyramidcorp/manifests/1_default.yaml
@@ -1,0 +1,156 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-master
+  labels:
+    app: redis
+    tier: backend
+    role: master
+spec:
+  ports:
+  - port: 6379
+    targetPort: 6379
+  selector:
+    app: redis
+    tier: backend
+    role: master
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: redis-master
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: master
+        tier: backend
+    spec:
+      containers:
+      - name: master
+        image: gcr.io/google_containers/redis:e2e  # or just image: redis
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 6379
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-slave
+  labels:
+    app: redis
+    tier: backend
+    role: slave
+spec:
+  ports:
+  - port: 6379
+  selector:
+    app: redis
+    tier: backend
+    role: slave
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: redis-slave
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: slave
+        tier: backend
+    spec:
+      containers:
+      - name: slave
+        image: gcr.io/google-samples/gb-redisslave:v1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 6379
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: signup
+  labels:
+    app: signup
+    tier: frontend
+spec:
+  ports:
+  - port: 80
+  selector:
+    app: signup
+    tier: frontend
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: signup
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: signup
+        tier: frontend
+    spec:
+      containers:
+      - name: signup-php
+        image: gcr.io/cjcullen-gke-dev/signup-form:v1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 80
+        imagePullPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: payment
+  labels:
+    app: payment
+spec:
+  ports:
+  - port: 80
+  selector:
+    app: payment
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: payment
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: payment
+    spec:
+      containers:
+      - name: payment-php
+        image: gcr.io/cjcullen-gke-dev/payment-processor:v1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 80
+        imagePullPolicy: Always
+---
+apiVersion: v1
+data:
+  payments-api-key: ZmNkYTM4YTQ2Mzc2NGRjNzUwNjk3YjU1MDQzMjM3MDhmM2YwNmM5ZQ==
+kind: Secret
+metadata:
+  name: payments-api-key

--- a/pyramidcorp/manifests/2_rbac_payments.yaml
+++ b/pyramidcorp/manifests/2_rbac_payments.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: payment
+  labels:
+    app: payment
+spec:
+  ports:
+  - port: 80
+  selector:
+    app: payment
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: payment
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: payment
+    spec:
+      containers:
+      - name: payment-php
+        image: gcr.io/cjcullen-gke-dev/payment-processor:v1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 80
+        imagePullPolicy: Always
+---
+apiVersion: v1
+data:
+  payments-api-key: ZmNkYTM4YTQ2Mzc2NGRjNzUwNjk3YjU1MDQzMjM3MDhmM2YwNmM5ZQ==
+kind: Secret
+metadata:
+  name: payments-api-key

--- a/pyramidcorp/manifests/2_rbac_signup.yaml
+++ b/pyramidcorp/manifests/2_rbac_signup.yaml
@@ -96,7 +96,7 @@ kind: Deployment
 metadata:
   name: signup
 spec:
-  replicas: 3
+  replicas: 1
   template:
     metadata:
       labels:
@@ -106,40 +106,6 @@ spec:
       containers:
       - name: signup-php
         image: gcr.io/cjcullen-gke-dev/signup-form:v1
-        resources:
-          requests:
-            cpu: 100m
-            memory: 100Mi
-        ports:
-        - containerPort: 80
-        imagePullPolicy: Always
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: payment
-  labels:
-    app: payment
-spec:
-  ports:
-  - port: 80
-  selector:
-    app: payment
----
-apiVersion: extensions/v1beta1
-kind: Deployment
-metadata:
-  name: payment
-spec:
-  replicas: 3
-  template:
-    metadata:
-      labels:
-        app: payment
-    spec:
-      containers:
-      - name: payment-php
-        image: gcr.io/cjcullen-gke-dev/payment-processor:v1
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
TODO: Flesh out scripts for setting up scenarios. But it's something like:
```
# scenario 1
kubectl create -f 1_default.yaml
# clean-up scenario 1
kubectl delete -f 1_default.yaml # or maybe just ignore it because the cluster is going away
# scenario 2
kubectl create ns signup
kubectl create ns payments
kubectl create -f 2_rbac_signup.yaml
kubectl create -f 2_rbac_payments.yaml
# cleanup scenario 2
kubectl delete -f 2_rbac_signup.yaml
kubectl delete -f 2_rbac_payments.yaml
```
TODO: Make 1 & 2 mount a hostPath volume that gets to kubelet creds.

Scenario 3 will then
- Not have the hostPath mount
- Not run as root (hopefully my php apps still work)
- Use anti-affinity or taints/tolerations